### PR TITLE
feat(subscription-auth): add ChatGPT/Codex device-auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ OpenAI credential handling:
 
 - **Direct BYOK (default)**: worker receives a plaintext OpenAI key (`OPENAI_API_KEY` / `CODEX_API_KEY`).
 - **Proxy-token mode (optional)**: worker receives an opaque token and routes requests through `oai_proxy` (plaintext key stays outside the worker).
+- **ChatGPT/Codex device-auth mode (optional)**: backend stores a base64-encoded `~/.codex/auth.json` and workers use that auth instead of per-request API keys.
 
 Enabling proxy-token mode:
 
@@ -70,6 +71,16 @@ cd backend
 cp .env.example .env
 # set BACKEND_OAI_KEY_MODE=proxy and OAI_PROXY_AES_KEY=...
 docker compose --profile proxy up -d --build
+```
+
+Enabling ChatGPT/Codex device-auth mode:
+
+```bash
+cd backend
+cp .env.example .env
+codex login --device-auth
+# set BACKEND_CODEX_AUTH_JSON_B64 to: base64 -w0 ~/.codex/auth.json
+docker compose up -d --build
 ```
 
 Operational note: worker runtime is bounded by default; override the max audit runtime with `EVM_BENCH_CODEX_TIMEOUT_SECONDS` (default: 10800 seconds).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -54,6 +54,12 @@ BACKEND_OAI_KEY_MODE=direct
 # vvv when set, openai keys aren't required in backend forms
 # BACKEND_STATIC_OAI_KEY=
 
+# Optional ChatGPT/Codex subscription mode (no per-request API key entry).
+# 1) Run locally: codex login --device-auth
+# 2) Encode auth file: base64 -w0 ~/.codex/auth.json
+# 3) Set value below to the base64 output:
+# BACKEND_CODEX_AUTH_JSON_B64=
+
 # vvv when unset, docker backend defaults to (CPU count)*3
 # INSTANCER_MAX_CONCURRENT_JOBS=5
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -31,6 +31,18 @@ Proxy-token mode (optional):
 docker compose --profile proxy up -d --build
 ```
 
+ChatGPT/Codex subscription mode (optional):
+
+```bash
+# Authenticate Codex once on the host
+codex login --device-auth
+
+# Put the base64-encoded auth file into backend/.env
+# BACKEND_CODEX_AUTH_JSON_B64=$(base64 -w0 ~/.codex/auth.json)
+
+docker compose up -d --build
+```
+
 ## k8s development
 ```bash
 # install kind from https://kind.sigs.k8s.io/docs/user/quick-start/

--- a/backend/api/core/config.py
+++ b/backend/api/core/config.py
@@ -48,6 +48,9 @@ class Settings(BaseSettings):
     BACKEND_OAI_KEY_MODE: Literal['direct', 'proxy'] = 'direct'
 
     BACKEND_STATIC_OAI_KEY: Secret[str] | None = None
+    # Optional base64-encoded ~/.codex/auth.json content for ChatGPT/Codex device-auth mode.
+    # When set, workers can authenticate Codex without user-provided OpenAI API keys.
+    BACKEND_CODEX_AUTH_JSON_B64: Secret[str] | None = None
     # When true, use the proxy's static key (sends "STATIC" marker instead of encrypted key)
     # The real OpenAI key is only known by oai_proxy, never exposed to backend or agents
     BACKEND_USE_PROXY_STATIC_KEY: bool = False

--- a/backend/api/routers/v1/integration.py
+++ b/backend/api/routers/v1/integration.py
@@ -12,5 +12,9 @@ router = APIRouter(prefix='/integration', tags=['integration'])
 async def frontend_config() -> FrontendConfig:
     return FrontendConfig(
         auth_enabled=bool(auth_backend),
-        key_predefined=settings.BACKEND_STATIC_OAI_KEY is not None or settings.BACKEND_USE_PROXY_STATIC_KEY,
+        key_predefined=(
+            settings.BACKEND_STATIC_OAI_KEY is not None
+            or settings.BACKEND_USE_PROXY_STATIC_KEY
+            or settings.BACKEND_CODEX_AUTH_JSON_B64 is not None
+        ),
     )

--- a/backend/api/routers/v1/jobs.py
+++ b/backend/api/routers/v1/jobs.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import os
 import uuid
 from contextlib import suppress
@@ -80,11 +82,30 @@ def _resolve_openai_key(form: StartJobForm) -> str | None:
     return static_key or form.openai_key
 
 
-async def _maybe_validate_user_key(*, form: StartJobForm, openai_key: str | None) -> None:
-    # Validate user-provided keys (skip if using static keys)
+def _resolve_codex_auth_json() -> str | None:
+    raw = settings.BACKEND_CODEX_AUTH_JSON_B64
+    if raw is None:
+        return None
+
+    try:
+        decoded = base64.b64decode(raw.get_secret_value()).decode('utf-8')
+        payload = json.loads(decoded)
+    except Exception as err:
+        raise HTTPException(status_code=500, detail='Invalid BACKEND_CODEX_AUTH_JSON_B64') from err
+
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=500, detail='Invalid BACKEND_CODEX_AUTH_JSON_B64 payload')
+
+    return decoded
+
+
+async def _maybe_validate_user_key(*, form: StartJobForm, openai_key: str | None, use_codex_auth: bool) -> None:
+    # Validate user-provided keys (skip if using static keys/device-auth)
     if settings.BACKEND_USE_PROXY_STATIC_KEY:
         return
     if settings.BACKEND_STATIC_OAI_KEY is not None:
+        return
+    if use_codex_auth:
         return
     if not form.openai_key:
         return
@@ -102,11 +123,24 @@ async def _maybe_validate_user_key(*, form: StartJobForm, openai_key: str | None
             raise HTTPException(status_code=401, detail='Invalid API key')
 
 
-def _encode_openai_token(*, openai_key: str, use_proxy_static: bool, use_proxy_tokens: bool) -> tuple[str, str]:
+def _encode_openai_token(
+    *,
+    openai_key: str | None,
+    use_proxy_static: bool,
+    use_proxy_tokens: bool,
+    use_codex_auth: bool,
+) -> tuple[str, str]:
     """Return (openai_token, key_mode) for the worker bundle."""
+    if use_codex_auth:
+        # Placeholder token; worker will use codex auth.json instead of API key login.
+        return 'CHATGPT_SUB', 'codex_auth'
+
     if use_proxy_static:
         # Marker token (not a real credential). The proxy substitutes its static key.
         return 'STATIC', 'proxy_static'
+
+    if openai_key is None:
+        raise HTTPException(status_code=412, detail='openai_key is required')
 
     if use_proxy_tokens:
         if settings.OAI_PROXY_AES_KEY is None:
@@ -134,25 +168,33 @@ async def start_job(
 
     use_proxy_static = settings.BACKEND_USE_PROXY_STATIC_KEY
     use_proxy_tokens = settings.BACKEND_OAI_KEY_MODE == 'proxy'
+    codex_auth_json = _resolve_codex_auth_json()
+    use_codex_auth = codex_auth_json is not None
     openai_key = _resolve_openai_key(form)
 
-    if not use_proxy_static and not openai_key:
+    if not use_proxy_static and not use_codex_auth and not openai_key:
         raise HTTPException(status_code=412, detail='openai_key is required')
 
-    await _maybe_validate_user_key(form=form, openai_key=openai_key)
+    await _maybe_validate_user_key(form=form, openai_key=openai_key, use_codex_auth=use_codex_auth)
 
     job_id = uuid.uuid4()
     secret_ref = os.urandom(32).hex()
     result_token = os.urandom(32).hex()
 
     openai_token, key_mode = _encode_openai_token(
-        openai_key=openai_key or '',
+        openai_key=openai_key,
         use_proxy_static=use_proxy_static,
         use_proxy_tokens=use_proxy_tokens,
+        use_codex_auth=use_codex_auth,
     )
 
     try:
-        bundle = build_secret_bundle(upload=form.file, openai_token=openai_token, key_mode=key_mode)
+        bundle = build_secret_bundle(
+            upload=form.file,
+            openai_token=openai_token,
+            key_mode=key_mode,
+            codex_auth_json=codex_auth_json,
+        )
         await secret_storage.save_secret(secret_ref, bundle)
 
         job = Job(

--- a/backend/api/schemas/job.py
+++ b/backend/api/schemas/job.py
@@ -45,10 +45,15 @@ class StartJobForm(BaseModel):
 
     @model_validator(mode='after')
     def require_openai_key(self) -> 'StartJobForm':
-        # Skip validation if using proxy's static key or backend's static key
+        # Skip validation if using proxy/static backend credentials.
         if settings.BACKEND_USE_PROXY_STATIC_KEY:
             return self
-        if settings.BACKEND_STATIC_OAI_KEY is None and not self.openai_key:
+        if settings.BACKEND_STATIC_OAI_KEY is not None:
+            return self
+        if settings.BACKEND_CODEX_AUTH_JSON_B64 is not None:
+            return self
+
+        if not self.openai_key:
             msg = 'openai_key is required'
             raise ValueError(msg)
         return self

--- a/backend/api/util/secrets_bundle.py
+++ b/backend/api/util/secrets_bundle.py
@@ -6,7 +6,13 @@ import orjson
 from fastapi import UploadFile
 
 
-def build_secret_bundle(*, upload: UploadFile, openai_token: str, key_mode: str) -> bytes:
+def build_secret_bundle(
+    *,
+    upload: UploadFile,
+    openai_token: str,
+    key_mode: str,
+    codex_auth_json: str | None = None,
+) -> bytes:
     upload_file = upload.file
 
     # NOTE(es3n1n): upload.size is optional
@@ -14,7 +20,10 @@ def build_secret_bundle(*, upload: UploadFile, openai_token: str, key_mode: str)
     upload_size = upload_file.tell()
     upload_file.seek(0)
 
-    key_payload = orjson.dumps({'openai_token': openai_token, 'key_mode': key_mode})
+    key_data: dict[str, str] = {'openai_token': openai_token, 'key_mode': key_mode}
+    if codex_auth_json is not None:
+        key_data['codex_auth_json'] = codex_auth_json
+    key_payload = orjson.dumps(key_data)
 
     buffer = io.BytesIO()
     with tarfile.open(fileobj=buffer, mode='w') as tar:

--- a/backend/docker/worker/init.py
+++ b/backend/docker/worker/init.py
@@ -69,6 +69,13 @@ def _write_codex_proxy_config(*, home: Path) -> None:
     config_path.write_text(config, encoding='utf-8')
 
 
+def _write_codex_auth_json(*, home: Path, codex_auth_json: str) -> None:
+    config_dir = home / '.codex'
+    config_dir.mkdir(parents=True, exist_ok=True)
+    auth_path = config_dir / 'auth.json'
+    auth_path.write_text(codex_auth_json, encoding='utf-8')
+
+
 def _load_model_map() -> dict[str, str]:
     try:
         data = json.loads(MODEL_MAP_PATH.read_text(encoding='utf-8'))
@@ -90,8 +97,13 @@ def _load_model_map() -> dict[str, str]:
     return model_map
 
 
-def _resolve_codex_model(*, model_key: str, model_map: dict[str, str]) -> str:
+def _resolve_codex_model(*, model_key: str, model_map: dict[str, str], key_mode: str) -> str:
     key = (model_key or '').strip()
+
+    # ChatGPT/Codex account auth should use Codex default model unless explicitly configured.
+    if key_mode == 'codex_auth':
+        return ''
+
     if key and key in model_map:
         return model_map[key]
     if key:
@@ -160,15 +172,28 @@ def _extract_json_payload(audit_md: str) -> dict:
     return _validate_report_payload(payload)
 
 
-def _run_codex_detect(*, openai_token: str, key_mode: str) -> Path:
+def _run_codex_detect(
+    *,
+    openai_token: str | None,
+    key_mode: str,
+    codex_auth_json: str | None,
+) -> Path:
     env = os.environ.copy()
-    env['OPENAI_API_KEY'] = openai_token
-    # Codex CLI supports using CODEX_API_KEY; keep it aligned to avoid surprises.
-    env['CODEX_API_KEY'] = openai_token
+    if key_mode == 'codex_auth':
+        env.pop('OPENAI_API_KEY', None)
+        env.pop('CODEX_API_KEY', None)
+    else:
+        token = openai_token or ''
+        env['OPENAI_API_KEY'] = token
+        # Codex CLI supports using CODEX_API_KEY; keep it aligned to avoid surprises.
+        env['CODEX_API_KEY'] = token
     env['HOME'] = str(AGENT_DIR)
     env['AGENT_DIR'] = str(AGENT_DIR)
     env['SUBMISSION_DIR'] = str(SUBMISSION_DIR)
     env['LOGS_DIR'] = str(LOGS_DIR)
+
+    if codex_auth_json:
+        _write_codex_auth_json(home=AGENT_DIR, codex_auth_json=codex_auth_json)
 
     # Proxy-token mode: write Codex config to route requests through oai_proxy.
     if key_mode in {'proxy', 'proxy_static'}:
@@ -182,8 +207,11 @@ def _run_codex_detect(*, openai_token: str, key_mode: str) -> Path:
         raise RuntimeError(msg)
 
     model_map = _load_model_map()
-    model = _resolve_codex_model(model_key=MODEL_KEY, model_map=model_map)
-    env['CODEX_MODEL'] = model
+    model = _resolve_codex_model(model_key=MODEL_KEY, model_map=model_map, key_mode=key_mode)
+    if model:
+        env['CODEX_MODEL'] = model
+    else:
+        env.pop('CODEX_MODEL', None)
     env['EVM_BENCH_DETECT_MD'] = str(DETECT_MD_PATH)
 
     LOGS_DIR.mkdir(parents=True, exist_ok=True)
@@ -209,7 +237,7 @@ def _run_codex_detect(*, openai_token: str, key_mode: str) -> Path:
     return audit_md_path
 
 
-def _unpack_bundle(bundle: bytes, work_dir: Path) -> tuple[Path, str, str]:
+def _unpack_bundle(bundle: bytes, work_dir: Path) -> tuple[Path, str | None, str, str | None]:  # noqa: C901
     upload_zip_path = work_dir / 'upload.zip'
     key_payload: dict | None = None
 
@@ -232,21 +260,32 @@ def _unpack_bundle(bundle: bytes, work_dir: Path) -> tuple[Path, str, str]:
 
     openai_token = key_payload.get('openai_token') or key_payload.get('openai_key')
     if not isinstance(openai_token, str) or not openai_token:
-        msg = 'Missing openai_token in bundle'
-        raise RuntimeError(msg)
+        openai_token = None
+
+    codex_auth_json = key_payload.get('codex_auth_json')
+    if not isinstance(codex_auth_json, str) or not codex_auth_json:
+        codex_auth_json = None
 
     key_mode = key_payload.get('key_mode') or 'direct'
     if not isinstance(key_mode, str):
         key_mode = 'direct'
     key_mode = key_mode.strip().lower()
-    if key_mode not in {'direct', 'proxy', 'proxy_static'}:
+    if key_mode not in {'direct', 'proxy', 'proxy_static', 'codex_auth'}:
         key_mode = 'direct'
+
+    if key_mode == 'codex_auth' and codex_auth_json is None:
+        msg = 'Missing codex_auth_json in bundle for codex_auth mode'
+        raise RuntimeError(msg)
+
+    if key_mode != 'codex_auth' and openai_token is None:
+        msg = 'Missing openai_token in bundle'
+        raise RuntimeError(msg)
 
     if not upload_zip_path.exists():
         msg = 'Missing upload.zip in bundle'
         raise RuntimeError(msg)
 
-    return upload_zip_path, openai_token, key_mode
+    return upload_zip_path, openai_token, key_mode, codex_auth_json
 
 
 async def main() -> None:
@@ -268,7 +307,7 @@ async def main() -> None:
 
     with tempfile.TemporaryDirectory(prefix='evmbench-worker-') as tmpdir:
         work_dir = Path(tmpdir)
-        upload_zip_path, openai_token, key_mode = _unpack_bundle(bundle, work_dir)
+        upload_zip_path, openai_token, key_mode, codex_auth_json = _unpack_bundle(bundle, work_dir)
 
         if AUDIT_DIR.exists():
             shutil.rmtree(AUDIT_DIR)
@@ -279,7 +318,11 @@ async def main() -> None:
 
         logger.info('Extracted the bundle, running detect-only agent...')
         try:
-            audit_md = _run_codex_detect(openai_token=openai_token, key_mode=key_mode)
+            audit_md = _run_codex_detect(
+                openai_token=openai_token,
+                key_mode=key_mode,
+                codex_auth_json=codex_auth_json,
+            )
             audit_text = audit_md.read_text()
             _extract_json_payload(audit_text)
 

--- a/backend/worker_runner/run_codex_detect.sh
+++ b/backend/worker_runner/run_codex_detect.sh
@@ -7,18 +7,14 @@ set -euo pipefail
 # - AGENT_DIR: directory containing audit/, submission/
 # - SUBMISSION_DIR: output dir (typically $AGENT_DIR/submission)
 # - LOGS_DIR: log directory
-# - OPENAI_API_KEY: plaintext key (direct mode) or opaque token (proxy mode)
-# - CODEX_API_KEY: same value as OPENAI_API_KEY (kept aligned)
-# - CODEX_MODEL: resolved Codex model id
+# - OPENAI_API_KEY/CODEX_API_KEY: required in API-key modes; optional when ~/.codex/auth.json exists
+# - CODEX_MODEL: optional override Codex model id
 # - EVM_BENCH_DETECT_MD: path to detect instructions markdown
 # - EVM_BENCH_CODEX_TIMEOUT_SECONDS: optional max runtime (default 10800)
 
 : "${AGENT_DIR:?missing AGENT_DIR}"
 : "${SUBMISSION_DIR:?missing SUBMISSION_DIR}"
 : "${LOGS_DIR:?missing LOGS_DIR}"
-: "${OPENAI_API_KEY:?missing OPENAI_API_KEY}"
-: "${CODEX_API_KEY:?missing CODEX_API_KEY}"
-: "${CODEX_MODEL:?missing CODEX_MODEL}"
 : "${EVM_BENCH_DETECT_MD:?missing EVM_BENCH_DETECT_MD}"
 
 mkdir -p "${SUBMISSION_DIR}" "${LOGS_DIR}"
@@ -40,12 +36,25 @@ LAUNCHER_PROMPT=$'You are an expert smart contract auditor.\nFirst read the AGEN
 
 AUTH_PATH="${AGENT_DIR}/.codex/auth.json"
 if [[ ! -f "${AUTH_PATH}" ]]; then
+  if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+    echo "missing OPENAI_API_KEY and missing ${AUTH_PATH}" >&2
+    exit 2
+  fi
+
+  # Keep CODEX_API_KEY aligned when using API-key flows.
+  export CODEX_API_KEY="${CODEX_API_KEY:-${OPENAI_API_KEY}}"
+
   # Avoid passing the token in argv; log output for debugging.
   printf '%s\n' "${OPENAI_API_KEY}" | codex login --with-api-key > "${LOGS_DIR}/codex_login.log" 2>&1 || true
 fi
 
+MODEL_ARGS=()
+if [[ -n "${CODEX_MODEL:-}" ]]; then
+  MODEL_ARGS=(--model "${CODEX_MODEL}")
+fi
+
 timeout --signal=KILL "${TIMEOUT_SECONDS}s" codex exec \
-  --model "${CODEX_MODEL}" \
+  "${MODEL_ARGS[@]}" \
   --dangerously-bypass-approvals-and-sandbox \
   --skip-git-repo-check \
   --experimental-json \

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -149,8 +149,8 @@ export default function Page() {
                   </p>
                   <p className="leading-tight">
                     This interface focuses on detection and only reports
-                    high-severity findings. Upload a contract folder, provide an
-                    API key, and start a run.
+                    high-severity findings. Upload a contract folder, configure
+                    credentials if needed, and start a run.
                   </p>
                   <div className="flex flex-col items-start gap-0.5">
                     <a
@@ -195,22 +195,49 @@ export default function Page() {
               />
 
               <div className="grid gap-3 text-xs text-muted-foreground">
-                {!isConfigLoading && !keyPredefined && (
-                  <div className="grid gap-1">
-                    <Label
-                      htmlFor="openai-key"
-                      className="text-xs text-foreground"
-                    >
-                      OpenAI API Key
-                    </Label>
-                    <Input
-                      id="openai-key"
-                      type="password"
-                      placeholder="sk-&hellip;"
-                      value={openaiKey}
-                      onChange={handleKeyChange}
-                    />
-                  </div>
+                {!isConfigLoading && (
+                  <>
+                    <div className="grid gap-1">
+                      <Label
+                        htmlFor="openai-key"
+                        className="text-xs text-foreground"
+                      >
+                        OpenAI API Key
+                      </Label>
+                      <Input
+                        id="openai-key"
+                        type="password"
+                        placeholder="sk-&hellip;"
+                        value={openaiKey}
+                        onChange={handleKeyChange}
+                      />
+                    </div>
+                    {keyPredefined && (
+                      <p className="text-[11px] text-muted-foreground">
+                        API key is optional on this deployment. Leave blank to
+                        use preconfigured credentials.
+                      </p>
+                    )}
+                    <details className="rounded-md border border-border/60 bg-muted/20 px-2 py-1.5">
+                      <summary className="cursor-pointer text-[11px] text-foreground">
+                        Connect a ChatGPT/Codex subscription (self-hosted)
+                      </summary>
+                      <div className="mt-1.5 space-y-1 text-[11px] text-muted-foreground">
+                        <p>For backend admins:</p>
+                        <ol className="list-decimal space-y-0.5 pl-4">
+                          <li>
+                            Run <code>codex login --device-auth</code>.
+                          </li>
+                          <li>
+                            Put <code>base64 -w0 ~/.codex/auth.json</code> in
+                            <code>BACKEND_CODEX_AUTH_JSON_B64</code> inside
+                            <code>backend/.env</code>.
+                          </li>
+                          <li>Restart backend and worker images.</li>
+                        </ol>
+                      </div>
+                    </details>
+                  </>
                 )}
                 <div className="grid gap-1">
                   <Label

--- a/frontend/src/lib/jobs.ts
+++ b/frontend/src/lib/jobs.ts
@@ -99,7 +99,9 @@ export async function startJob(
   const body = new FormData()
   body.append("file", file)
   body.append("model", model)
-  body.append("openai_key", openaiKey)
+  if (openaiKey.trim().length > 0) {
+    body.append("openai_key", openaiKey)
+  }
 
   const response = await fetch(`${API_BASE}/v1/jobs/start`, {
     method: "POST",


### PR DESCRIPTION
- Adds optional backend credential mode via BACKEND_CODEX_AUTH_JSON_B64 (base64 of ~/.codex/auth.json).
- Keeps BYOK API-key flow as default.
- Enables worker-side Codex auth via injected ~/.codex/auth.json.
- Makes frontend API key optional when backend credentials are preconfigured.
- Adds frontend instructions dropdown for subscription setup.
- Updates docs (README.md, backend/README.md, .env.example).

The code for this PR was written by Codex (using takopi as a harness). I can verify that the code works on my end, enabling running `evmbench` with a subscription.