### PR TITLE
Add GPT-5.4 and GPT-5.3 Codex options

### DIFF
--- a/backend/api/core/const.py
+++ b/backend/api/core/const.py
@@ -1,4 +1,6 @@
 ALLOWED_MODELS = {
+    'codex-gpt-5.3-codex',
+    'codex-gpt-5.4',
     'codex-gpt-5.1-codex-max',
     'codex-gpt-5.2',
 }

--- a/backend/worker_runner/model_map.json
+++ b/backend/worker_runner/model_map.json
@@ -1,5 +1,6 @@
 {
+  "codex-gpt-5.4": "gpt-5.4",
+  "codex-gpt-5.3-codex": "gpt-5.3-codex",
   "codex-gpt-5.2": "gpt-5.2-2025-12-11",
   "codex-gpt-5.1-codex-max": "gpt-5.1-codex-max"
 }
-

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -224,6 +224,12 @@ export default function Page() {
                       <SelectValue placeholder="Select model" />
                     </SelectTrigger>
                     <SelectContent>
+                      <SelectItem value="codex-gpt-5.4">
+                        codex-gpt-5.4
+                      </SelectItem>
+                      <SelectItem value="codex-gpt-5.3-codex">
+                        codex-gpt-5.3-codex
+                      </SelectItem>
                       <SelectItem value="codex-gpt-5.2">
                         codex-gpt-5.2
                       </SelectItem>


### PR DESCRIPTION
## Summary
- add `codex-gpt-5.4` and `codex-gpt-5.3-codex` to the frontend model selector
- allow both model keys in the backend allowlist
- map the new UI keys to raw Codex model IDs in the worker model map

## Verification
- `bun run build`
- started the backend stack locally with Docker and confirmed `http://127.0.0.1:1337/v1/integration/frontend` responds
- submitted dummy `/v1/jobs/start` requests with both new model keys and confirmed they pass model validation and reach the expected `412 openai_key is required` path

## Notes
- `bun run lint` still reports a pre-existing import-order issue in `frontend/src/components/results/results-header.tsx` unrelated to this change